### PR TITLE
Bump symfony/process up to ^6.0 and psr/log up to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     ],
     "require": {
         "php": "7.4.* || 8.0.* || 8.1.*",
-        "psr/log": "^1.1",
-        "symfony/process": "^4.4 || ^5.4"
+        "psr/log": "^1.1 || ^2.0 || ^3.0",
+        "symfony/process": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",

--- a/src/AbstractGenerator.php
+++ b/src/AbstractGenerator.php
@@ -125,11 +125,9 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
         return $this->getOutput($fileName, $options);
     }
 
-    public function setLogger(LoggerInterface $logger): self
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
-
-        return $this;
     }
 
     /**


### PR DESCRIPTION
This PR allow installation with Symfony 6.0 app.
Changes only affect argument and return types with no BC.