### PR TITLE
Stylesheets not able to be an array fix

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -41,7 +41,7 @@ class Pdf extends AbstractGenerator
             }
 
             if (!empty($value) && \array_key_exists($option, $this->optionsWithContentCheck)) {
-                $saveToTempFile = !$this->isFile($value) && !$this->isOptionUrl($value);
+                $saveToTempFile = is_string($value) && !$this->isFile($value) && !$this->isOptionUrl($value);
                 $fetchUrlContent = 'attachment' === $option && $this->isOptionUrl($value);
 
                 if ($saveToTempFile || $fetchUrlContent) {


### PR DESCRIPTION
When trying to add stylesheets to the PDF document, I got an error as the `isFile` method only allowed strings. Adding an `is_string` check fixed this issue.