### PR TITLE
Always pass through timeout when creating a process

### DIFF
--- a/src/AbstractGenerator.php
+++ b/src/AbstractGenerator.php
@@ -191,12 +191,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
      */
     protected function executeCommand(string $command): array
     {
-        $process = Process::fromShellCommandline($command, null, $this->env);
-
-        if (null !== $this->timeout) {
-            $process->setTimeout($this->timeout);
-        }
-
+        $process = Process::fromShellCommandline($command, null, $this->env, null, $this->timeout);
         $process->run();
 
         return [


### PR DESCRIPTION
The `Symfony\Component\Process\Process` class allows setting a null value for the timeout, indicating the process does not have a timeout.  The generator class only configures the timeout when it is a non-null value, making it impossible to configure the generator to run without a timeout (i.e. in a command line context as a system job where a long-running process is intended).

This change allows configuring the process to have no timeout by always passing through the timeout value from the generator.

This will have no B/C impact as the generator's constructor has an explicit `$this->setTimeout()` call with a default timeout.