### PR TITLE
Ensure setTimeout option is correctly passed to WeasyPrint

### DIFF
--- a/src/AbstractGenerator.php
+++ b/src/AbstractGenerator.php
@@ -253,6 +253,7 @@ abstract class AbstractGenerator implements GeneratorInterface, LoggerAwareInter
     public function setTimeout(?int $timeout): self
     {
         $this->timeout = $timeout;
+        $this->options['timeout'] = $timeout;
 
         return $this;
     }


### PR DESCRIPTION
## Description:
Currently, php-weasyprint allows setting a timeout usingsetTimeout(), but this option is not correctly propagated to the underlying WeasyPrint process. As a result, setting a timeout via setTimeout() does not affect HTTP request timeouts during PDF generation. Although you can set the timeout manually with setOption('timeout', '60'), this means that there are two different timeout options to consider.

### Solution:
- Ensure that the timeout option set via setTimeout() is correctly included in the WeasyPrint command.
- This unifies timeout handling and avoids confusion caused by multiple timeout mechanisms.

### Benefits:
- The timeout configuration now works as expected, giving users proper control over request timeouts.
- Eliminates redundancy by ensuring a single timeout mechanism is respected.

This change improves consistency and usability for developers using php-weasyprint in environments where network performance may vary.